### PR TITLE
Increased speed by ignoring all NULL bytes in string

### DIFF
--- a/index.js
+++ b/index.js
@@ -492,8 +492,17 @@ class Field {
         switch (this.type) {
             case 1:
                 //        |      |            $01     v   "A"  Alpha                                   |
-                this.value = value.toString(encoding)
-                break
+                const fieldSize = value.length;
+                const bytesForString = [];
+                for (let i = 0; i < fieldSize; i++) {
+                    const b = value[i];
+                    if (b !== 0) {
+                        bytesForString.push(b);
+                    }
+                }
+
+                this.value = String.fromCharCode(...bytesForString);
+                break;
             case 2:
                 //        |      |            $02     4   "D"  Date                                    |
                 this.value = convertDate(this.valueBuffer)


### PR DESCRIPTION
Since a string in paradox is always filled completely to the size of a string, it contains many NULL bytes ASCII char 0 that were also transformed in the toString method. By avoiding it, it will only transform real ASCII characters to string.